### PR TITLE
Add mkdocs user guide and API docs

### DIFF
--- a/docs/api/allocate.md
+++ b/docs/api/allocate.md
@@ -1,0 +1,3 @@
+# scythe.allocate
+
+::: scythe.allocate

--- a/docs/api/base.md
+++ b/docs/api/base.md
@@ -1,0 +1,3 @@
+# scythe.base
+
+::: scythe.base

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -1,0 +1,3 @@
+# scythe.registry
+
+::: scythe.registry

--- a/docs/api/scatter_gather.md
+++ b/docs/api/scatter_gather.md
@@ -1,0 +1,3 @@
+# scythe.scatter_gather
+
+::: scythe.scatter_gather

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,7 @@
+# scythe.utils
+
+::: scythe.utils.filesys
+
+::: scythe.utils.results
+
+::: scythe.utils.s3

--- a/docs/api/worker.md
+++ b/docs/api/worker.md
@@ -1,0 +1,3 @@
+# scythe.worker
+
+::: scythe.worker

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,5 @@
 # Scythe
+
+**Scythe** is a lightweight helper library for orchestrating large numbers of simulations using the [Hatchet](https://hatchet.run) distributed task queue.  It focuses on the common pattern of *scatter* (fan out) and *gather* (combine results) while handling artifact uploads, specification validation and result storage.
+
+This documentation contains a brief user guide and an API reference generated from the Python modules in `src/scythe`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,47 @@
+# User Guide
+
+This guide explains how to use **Scythe** to manage embarrassingly parallel experiments with [Hatchet](https://hatchet.run).
+
+## Installation
+
+Install the package from PyPI:
+
+```bash
+pip install scythe-engine
+```
+
+## Creating Experiments
+
+1. Define input and output specifications by subclassing `ExperimentInputSpec` and `ExperimentOutputSpec` from `scythe.base`.
+2. Decorate an experiment function with `@ExperimentRegistry.Register()` to expose it as a Hatchet workflow.
+3. Optionally start a `ScytheWorker` to run the workflows.
+
+## Allocating Experiments
+
+Use `allocate_experiment` from `scythe.allocate` to upload specs and trigger the scatter/gather workflow. The function handles uploading local artifacts and creates a manifest describing the experiment run.
+
+## Results
+
+Outputs are stored as Parquet files in your configured S3 bucket. Scalar results are combined in `scalars.pq`. Additional data frames can be added via the `dataframes` field of `ExperimentOutputSpec`.
+
+## Example
+
+A minimal example creating an experiment is shown below:
+
+```python
+from pydantic import Field
+from scythe.base import ExperimentInputSpec, ExperimentOutputSpec
+from scythe.registry import ExperimentRegistry
+
+class MyInput(ExperimentInputSpec):
+    value: int = Field(...)
+
+class MyOutput(ExperimentOutputSpec):
+    doubled: int = Field(...)
+
+@ExperimentRegistry.Register()
+def double(input_spec: MyInput) -> MyOutput:
+    return MyOutput(doubled=input_spec.value * 2)
+```
+
+The registry exposes the experiment as a Hatchet workflow which can be executed via scatter/gather.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,14 @@ copyright: Maintained by <a href="https://github.com/szvsw">Sam Wolk</a>.
 
 nav:
   - Home: index.md
+  - User Guide: user_guide.md
+  - API Reference:
+      - base: api/base.md
+      - allocate: api/allocate.md
+      - scatter_gather: api/scatter_gather.md
+      - registry: api/registry.md
+      - worker: api/worker.md
+      - utils: api/utils.md
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## Summary
- add a short introduction in `docs/index.md`
- write a getting started guide
- add API reference pages and navigation

## Testing
- `pytest -q`
- `mkdocs build --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68818d5f3590832bae011012b15bfc1d