### PR TITLE
Add coverage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ cython_debug/
 .env.copilot
 data/cache
 cache/
+requirements.txt

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scythe.base import ExperimentInputSpec, ExperimentOutputSpec
+from scythe.types import S3Url, FileReference
+
+
+class Inp(ExperimentInputSpec):
+    val: int
+    file: FileReference
+
+
+class Out(ExperimentOutputSpec):
+    num: int | None = None
+
+
+def test_fetch_uri_edge_cases(monkeypatch, tmp_path):
+    from scythe.utils.filesys import fetch_uri
+
+    dest = tmp_path / "f.txt"
+    # S3 missing bucket
+    with pytest.raises(ValueError):
+        fetch_uri("s3:///foo", dest, use_cache=False)
+
+    # http skip when cached
+    class DummyResp:
+        def __init__(self, content):
+            self.content = content
+    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResp(b"h"))
+    fetch_uri("http://x", dest, use_cache=False)
+    before = dest.read_bytes()
+    fetch_uri("http://x", dest, use_cache=True)
+    assert dest.read_bytes() == before
+
+    # file scheme with missing path
+    class DummyFile:
+        scheme = "file"
+        path = ""
+    with pytest.raises(ValueError):
+        fetch_uri(DummyFile(), dest, use_cache=False)
+    # s3 skip when cached
+    class DummyS3:
+        def __init__(self):
+            self.downloaded = []
+        def download_file(self, bucket, key, filename):
+            self.downloaded.append((bucket, key, filename))
+    ds = DummyS3()
+    monkeypatch.setattr("scythe.utils.filesys.s3", ds)
+    uri = S3Url("s3://bucket/foo")
+    fetch_uri(uri, dest, use_cache=False, s3=ds)
+    first = dest.read_bytes()
+    fetch_uri(uri, dest, use_cache=True, s3=ds)
+    assert dest.read_bytes() == first
+    assert len(ds.downloaded) == 1
+
+def test_save_and_upload_parquets_skip(monkeypatch, tmp_path):
+    from scythe.utils.results import save_and_upload_parquets
+
+    class DummyS3:
+        def __init__(self):
+            self.uploaded = []
+        def upload_file(self, Bucket, Key, Filename):
+            self.uploaded.append((Bucket, Key))
+    ds = DummyS3()
+    df = pd.DataFrame({"a": [1]})
+    uris = save_and_upload_parquets(
+        {"error_result": df, "ok": df},
+        ds,
+        "b",
+        lambda n: f"{n}.pq",
+        save_errors=False,
+    )
+    assert "ok" in uris and "error_result" not in uris
+    assert ("b", "ok.pq") in ds.uploaded
+
+def test_register_decorator_exec(monkeypatch):
+    from scythe import registry as reg
+
+    reg.ExperimentRegistry._experiments_dict.clear()
+    monkeypatch.setattr(reg.ExperimentRegistry, "Include", classmethod(lambda cls, t: t))
+
+    def dummy_task(**kw):
+        def deco(fn):
+            fn.decorated_name = kw.get("name")
+            return fn
+        return deco
+    monkeypatch.setattr(reg, "hatchet", types.SimpleNamespace(task=dummy_task))
+
+    @reg.ExperimentRegistry.Register()
+    def fn(input_spec: Inp) -> Out:
+        return Out(num=1)
+
+    ctx = types.SimpleNamespace(log=lambda m: None, workflow_run_id="wr")
+    spec = Inp(experiment_id="e", sort_index=0, val=5, file=Path("/tmp/x"))
+    out = fn(spec, ctx)
+    assert spec.workflow_run_id == "wr"
+    assert hasattr(out, "dataframes") and "scalars" in out.dataframes
+
+def test_scatter_gather_base_case(monkeypatch, tmp_path):
+    from scythe.scatter_gather import ScatterGatherInput, RecursionMap, scatter_gather, GatheredExperimentRuns
+
+    df = pd.DataFrame({"x": [1]})
+    async def fake_run_experiments(self):
+        return GatheredExperimentRuns(success=ExperimentOutputSpec(dataframes={"d": df}), errors=None)
+    monkeypatch.setattr(ScatterGatherInput, "run_experiments", fake_run_experiments)
+
+    monkeypatch.setattr("scythe.scatter_gather.save_and_upload_parquets", lambda collected_dfs, **k: {kname: S3Url(f"s3://b/{kname}") for kname in collected_dfs})
+    monkeypatch.setattr("scythe.scatter_gather.fetch_uri", lambda uri, local_path, use_cache: tmp_path)
+
+    spec = Inp(experiment_id="e", sort_index=0, val=1, file=tmp_path/"f")
+    rm = RecursionMap(path=None, factor=2, max_depth=1)
+    sgi = ScatterGatherInput(experiment_id="e", task_name="t", specs_uri=S3Url("s3://b/k"), recursion_map=rm)
+    sgi.__dict__["specs"] = [spec]
+    ctx = types.SimpleNamespace(workflow_run_id="wr")
+    res = asyncio.run(scatter_gather(sgi, ctx))
+    assert "d" in res.uris
+
+def test_scatter_gather_recursive(monkeypatch, tmp_path):
+    from scythe.scatter_gather import ScatterGatherInput, RecursionMap, scatter_gather
+
+    async def fake_aio_run_many(trigs, return_exceptions=True):
+        class Dummy:
+            def to_gathered_experiment_runs(self):
+                return types.SimpleNamespace(success=ExperimentOutputSpec(dataframes={"d": pd.DataFrame({"x": [2]})}), errors=None)
+        return [Dummy()]
+    import scythe.scatter_gather as sg_mod
+    monkeypatch.setattr(sg_mod.scatter_gather, "aio_run_many", fake_aio_run_many, raising=False)
+
+    def fake_create(self, wr):
+        return ["trig"], [types.SimpleNamespace(model_dump=lambda mode='json': {"v": 1})]
+    monkeypatch.setattr(ScatterGatherInput, "create_recursion_payloads", fake_create)
+    monkeypatch.setattr("scythe.scatter_gather.save_and_upload_parquets", lambda collected_dfs, **k: {kname: S3Url(f"s3://b/{kname}") for kname in collected_dfs})
+    monkeypatch.setattr("scythe.scatter_gather.fetch_uri", lambda uri, local_path, use_cache: tmp_path)
+
+    spec = Inp(experiment_id="e", sort_index=0, val=1, file=tmp_path/"f")
+    rm = RecursionMap(path=None, factor=1, max_depth=2)
+    sgi = ScatterGatherInput(experiment_id="e", task_name="t", specs_uri=S3Url("s3://b/k"), recursion_map=rm)
+    sgi.__dict__["specs"] = [spec, spec]
+    ctx = types.SimpleNamespace(workflow_run_id="wr")
+    res = asyncio.run(scatter_gather(sgi, ctx))
+    assert "d" in res.uris
+
+def test_allocate_experiment_errors(monkeypatch, tmp_path):
+    from scythe.allocate import allocate_experiment, DuplicateInputArtifactsError
+    class DummyExp:
+        name = "d"
+        config = type("cfg", (), {"input_validator": Inp})
+        input_validator = Inp
+        _output_validator = Out
+    f = tmp_path/"dir1"/"x.txt"
+    f.parent.mkdir()
+    f.write_text("x")
+    f2 = tmp_path/"dir2"/"x.txt"
+    f2.parent.mkdir()
+    f2.write_text("y")
+    spec1 = Inp(experiment_id="e", sort_index=0, val=1, file=f)
+    spec2 = Inp(experiment_id="e", sort_index=1, val=2, file=f2)
+    with pytest.raises(DuplicateInputArtifactsError):
+        allocate_experiment("e", DummyExp(), [spec1, spec2], s3_client=types.SimpleNamespace(upload_file=lambda **k: None))
+
+    DummyExp._output_validator = None  # type: ignore[assignment]
+    monkeypatch.setattr(
+        "scythe.allocate.save_and_upload_parquets",
+        lambda collected_dfs, **k: {n: S3Url(f"s3://b/{n}") for n in collected_dfs},
+    )
+    monkeypatch.setattr(
+        "scythe.allocate.scatter_gather",
+        types.SimpleNamespace(run_no_wait=lambda *a, **k: types.SimpleNamespace(workflow_run_id="wr")),
+    )
+    monkeypatch.setattr(
+        "scythe.allocate.upload_input_artifacts",
+        lambda arts, *a, **k: (
+            types.SimpleNamespace(files={"file": {S3Url("s3://b/art")}}),
+            {"file": {next(iter(arts["file"])): S3Url("s3://b/art")}},
+        ),
+    )
+    with pytest.raises(ValueError):
+        allocate_experiment("e", DummyExp(), [spec1], s3_client=types.SimpleNamespace(upload_file=lambda **k: None))
+
+def test_scatter_gather_main(monkeypatch):
+    import runpy, builtins
+    recorded = []
+    monkeypatch.setattr(builtins, "print", lambda *a, **k: recorded.append(a))
+    runpy.run_module("scythe.scatter_gather", run_name="__main__")
+    assert recorded

--- a/tests/test_allocate_worker.py
+++ b/tests/test_allocate_worker.py
@@ -1,0 +1,135 @@
+import os
+import sys
+import types
+from pathlib import Path
+import pandas as pd
+import pytest
+sys.modules['scythe.hatchet'] = types.SimpleNamespace(
+    hatchet=types.SimpleNamespace(task=lambda *a, **k: (lambda f: f), worker=lambda **k: types.SimpleNamespace(register_workflow=lambda w: None, start=lambda: None))
+)
+os.environ.setdefault(
+    "HATCHET_CLIENT_TOKEN",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.signature",
+)
+os.environ.setdefault("HATCHET_CLIENT_SERVER_URL", "http://localhost")
+os.environ.setdefault("HATCHET_CLIENT_HOST_PORT", "localhost:1234")
+os.environ.setdefault("HATCHET_CLIENT_SUB", "t")
+os.environ.setdefault("SCYTHE_STORAGE_BUCKET", "b")
+
+from scythe.base import ExperimentInputSpec, ExperimentOutputSpec
+
+
+from scythe.types import FileReference
+
+
+class MyInput(ExperimentInputSpec):
+    a: int
+    file: FileReference
+
+
+class MyOutput(ExperimentOutputSpec):
+    b: int | None = None
+
+
+class DummyS3:
+    def __init__(self):
+        self.uploaded: list[tuple[str, str, str]] = []
+
+    def upload_file(self, Bucket: str, Key: str, Filename: str) -> None:
+        self.uploaded.append((Bucket, Key, Filename))
+
+
+def test_upload_input_artifacts(tmp_path):
+    from scythe.allocate import upload_input_artifacts
+    f1 = tmp_path / "a.txt"
+    f1.write_text("x")
+    f2 = tmp_path / "b.txt"
+    f2.write_text("y")
+    artifacts = {"file": {f1, f2}}
+    ds = DummyS3()
+
+    def key_builder(p: Path, field: str) -> str:
+        return f"prefix/{field}/{p.name}"
+
+    locs, maps = upload_input_artifacts(artifacts, ds, "bucket", key_builder)
+    assert locs.files["file"]
+    assert maps["file"][f1].path.endswith("a.txt")
+    assert ("bucket", "prefix/file/a.txt", f1.as_posix()) in ds.uploaded
+
+
+
+def test_allocate_experiment_basic(monkeypatch, tmp_path):
+    from scythe.allocate import (
+        allocate_experiment,
+        InputArtifactLocations,
+    )
+    from scythe.types import S3Url
+    class DummyExp:
+        name = "dummy"
+        config = type("cfg", (), {"input_validator": MyInput})
+        input_validator = MyInput
+        _output_validator = MyOutput
+
+    ds = DummyS3()
+
+    def fake_run_no_wait(payload, options):
+        class R:
+            workflow_run_id = "wr"
+        return R()
+
+    monkeypatch.setattr("scythe.allocate.scatter_gather", type("SG", (), {"run_no_wait": staticmethod(fake_run_no_wait)}))
+
+    def fake_upload_input_artifacts(arts, s3_client, bucket, key_fn):
+        maps = {f: {p: S3Url(f"s3://{bucket}/{key_fn(p,f)}") for p in ps} for f, ps in arts.items()}
+        locs = InputArtifactLocations(files={f: set(u for u in m.values()) for f, m in maps.items()})
+        return locs, maps
+
+    monkeypatch.setattr("scythe.allocate.upload_input_artifacts", fake_upload_input_artifacts)
+
+    tmp_file = tmp_path / "f.txt"
+    tmp_file.write_text("hi")
+    spec = MyInput(experiment_id="", sort_index=0, a=1, file=tmp_file)
+
+    res = allocate_experiment("exp", DummyExp(), [spec], s3_client=ds)
+    assert res.workflow_run_id == "wr"
+    assert isinstance(spec.file, S3Url)
+    assert ds.uploaded  # manifest and schema
+
+
+def test_allocate_experiment_type_error(tmp_path):
+    from scythe.allocate import allocate_experiment, ExperimentSpecsMismatchError
+    class DummyExp:
+        name = "dummy"
+        config = type("cfg", (), {"input_validator": MyInput})
+        input_validator = MyInput
+        _output_validator = MyOutput
+
+    bad_spec = MyOutput()  # type: ignore[arg-type]
+    with pytest.raises(ExperimentSpecsMismatchError):
+        allocate_experiment("exp", DummyExp(), [bad_spec], s3_client=DummyS3())
+
+
+def test_worker_config(monkeypatch):
+    from scythe.worker import WorkerNameConfig, ScytheWorkerConfig
+    wn = WorkerNameConfig(FLY_REGION="dfw")
+    assert wn.fly_hosting_str == "FlyDFW"
+    wn = WorkerNameConfig(AWS_BATCH_JOB_ARRAY_INDEX=1)
+    assert wn.aws_hosting_str.endswith("0001")
+    sw = ScytheWorkerConfig(NAME=None, WORKER_NAME_CONFIG=wn, SLOTS=None, DURABLE_SLOTS=None)
+    monkeypatch.setattr(os, "cpu_count", lambda: 4)
+    assert sw.computed_slots == 4
+    assert sw.computed_durable_slots == 1000
+    assert sw.computed_name.startswith("ScytheWorker")
+
+    recorded = []
+    class DW:
+        def register_workflow(self, wf):
+            recorded.append(wf)
+        def start(self):
+            recorded.append("started")
+    monkeypatch.setattr("scythe.worker.hatchet", type("H", (), {"worker": lambda **kw: DW()}))
+    monkeypatch.setattr("scythe.worker.ExperimentRegistry", type("ER", (), {"experiments": staticmethod(lambda: ["wf"]), "Register": staticmethod(lambda: (lambda f: f))}))
+    sw.start([lambda x: x])
+    assert "started" in recorded
+
+

--- a/tests/test_hatchet.py
+++ b/tests/test_hatchet.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+
+
+def test_hatchet_import(monkeypatch):
+    created = {}
+
+    class Dummy:
+        def __init__(self):
+            created['ok'] = True
+
+    monkeypatch.setattr('hatchet_sdk.Hatchet', Dummy)
+    sys.modules.pop('scythe.hatchet', None)
+    module = importlib.import_module('scythe.hatchet')
+    assert isinstance(module.hatchet, Dummy)
+    assert created.get('ok') is True

--- a/tests/test_registry_and_scatter.py
+++ b/tests/test_registry_and_scatter.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import types
+import pandas as pd
+import pytest
+import asyncio
+
+def dummy_task(**kw):
+    def deco(fn):
+        fn.name = kw.get("name", fn.__name__)
+        return fn
+    return deco
+
+dummy_worker = types.SimpleNamespace(register_workflow=lambda w: None, start=lambda: None)
+sys.modules['scythe.hatchet'] = types.SimpleNamespace(
+    hatchet=types.SimpleNamespace(task=dummy_task, worker=lambda **k: dummy_worker)
+)
+os.environ.setdefault("SCYTHE_STORAGE_BUCKET", "b")
+
+from pathlib import Path
+from scythe.base import ExperimentInputSpec, ExperimentOutputSpec
+from scythe.types import S3Url
+
+class Inp(ExperimentInputSpec):
+    val: int
+
+class Out(ExperimentOutputSpec):
+    pass
+
+
+def test_registry_include_and_get():
+    from scythe.registry import ExperimentRegistry, ExperimentTypeExists, ExperimentTypeNotFound
+    ExperimentRegistry._experiments_dict.clear()
+    dummy = types.SimpleNamespace(name="foo", config=None)
+    out = ExperimentRegistry.Include(dummy)
+    assert ExperimentRegistry.get_experiment("foo") is dummy
+    with pytest.raises(ExperimentTypeExists):
+        ExperimentRegistry.Include(dummy)
+    with pytest.raises(ExperimentTypeNotFound):
+        ExperimentRegistry.get_experiment("bar")
+
+
+def test_register_decorator():
+    from scythe.registry import ExperimentRegistry
+    ExperimentRegistry._experiments_dict.clear()
+    monkeypatch_include = lambda task: task
+    ExperimentRegistry.Include = classmethod(lambda cls, t: monkeypatch_include(t))
+
+    @ExperimentRegistry.Register()
+    def fn(input_spec: Inp) -> Out:
+        return Out()
+
+    assert callable(fn)
+
+
+def test_run_experiments(monkeypatch, tmp_path):
+    from scythe.scatter_gather import ScatterGatherInput, RecursionMap
+    from scythe.registry import ExperimentRegistry
+
+    class Standalone:
+        def create_bulk_run_item(self, input, options):
+            return input
+        async def aio_run_many(self, inputs, return_exceptions=True):
+            return [Out(dataframes={"d": pd.DataFrame({"x": [i]})}) for i,_ in enumerate(inputs)]
+
+    spec = Inp(experiment_id="e", sort_index=0, val=1)
+    sgi = ScatterGatherInput(
+        experiment_id="e",
+        task_name="task",
+        specs_uri=S3Url("s3://b/k"),
+        recursion_map=RecursionMap(path=None, factor=2, max_depth=1),
+    )
+    sgi.__dict__["specs"] = [spec, spec]
+    monkeypatch.setattr(ExperimentRegistry, "get_experiment", lambda name: Standalone())
+    result = asyncio.run(sgi.run_experiments())
+    assert result.success.dataframes["d"].shape[0] == 2
+
+
+def test_create_recursion_payloads(monkeypatch, tmp_path):
+    from scythe.scatter_gather import ScatterGatherInput, RecursionMap
+    import scythe.scatter_gather as sg_mod
+
+    spec = Inp(experiment_id="e", sort_index=0, val=1)
+    sgi = ScatterGatherInput(
+        experiment_id="e",
+        task_name="task",
+        specs_uri=S3Url("s3://b/k"),
+        recursion_map=RecursionMap(path=None, factor=2, max_depth=2),
+    )
+    sgi.__dict__["specs"] = [spec, spec, spec, spec]
+    monkeypatch.setattr(
+        sg_mod,
+        "save_and_upload_parquets",
+        lambda collected_dfs, *a, **k: {kname: S3Url(f"s3://b/{kname}") for kname in collected_dfs},
+    )
+    monkeypatch.setattr(sg_mod, "scatter_gather", types.SimpleNamespace(create_bulk_run_item=lambda input, options: (input, options)))
+    trigs, payloads = sgi.create_recursion_payloads("wr")
+    assert len(payloads) == 2
+    assert trigs[0][1].additional_metadata["level"] == 0
+

--- a/tests/test_scatter_gather.py
+++ b/tests/test_scatter_gather.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+import pandas as pd
+import pytest
+import os
+import sys
+import types
+sys.modules['scythe.hatchet'] = types.SimpleNamespace(
+    hatchet=types.SimpleNamespace(task=lambda *a, **k: (lambda f: f), worker=lambda **k: types.SimpleNamespace(register_workflow=lambda w: None, start=lambda: None))
+)
+os.environ.setdefault(
+    "HATCHET_CLIENT_TOKEN",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.signature",
+)
+os.environ.setdefault("HATCHET_CLIENT_SERVER_URL", "http://localhost")
+os.environ.setdefault("HATCHET_CLIENT_HOST_PORT", "localhost:1234")
+os.environ.setdefault("HATCHET_CLIENT_SUB", "t")
+os.environ.setdefault("SCYTHE_STORAGE_BUCKET", "b")
+
+from scythe.base import ExperimentInputSpec, ExperimentOutputSpec
+from scythe.types import S3Url
+
+
+class MyInput(ExperimentInputSpec):
+    a: int
+    file: Path
+
+
+class MyOutput(ExperimentOutputSpec):
+    b: int | None = None
+
+
+def test_recursion_spec_validation():
+    from scythe.scatter_gather import RecursionSpec
+    RecursionSpec(factor=2, offset=1)
+    with pytest.raises(ValueError):
+        RecursionSpec(factor=2, offset=2)
+
+
+def test_recursion_map_properties():
+    from scythe.scatter_gather import RecursionMap
+    rm = RecursionMap(path=None, factor=2, max_depth=1)
+    assert rm.is_root
+    with pytest.raises(ValueError):
+        RecursionMap(path=[], factor=2, max_depth=1)
+
+
+def test_construct_filekey_and_base_case(tmp_path):
+    from scythe.scatter_gather import RecursionMap, ScatterGatherInput
+    spec = MyInput(experiment_id="exp", sort_index=0, file=tmp_path/"f", a=1)
+    sgi = ScatterGatherInput(
+        experiment_id="exp",
+        task_name="task",
+        specs_uri=S3Url("s3://b/key"),
+        recursion_map=RecursionMap(path=None, factor=2, max_depth=1),
+    )
+    sgi.__dict__["specs"] = [spec]
+    key = sgi.construct_filekey(
+        "file",
+        mode="input",
+        workflow_run_id="wr",
+        suffix="pq",
+    )
+    assert key.endswith("scatter-gather/input/root/wr/file.pq")
+    sgi.add_root_workflow_run_id("root")
+    assert spec.root_workflow_run_id == "root"
+    assert sgi.is_base_case
+
+
+def test_create_and_combine(monkeypatch, tmp_path):
+    from scythe.scatter_gather import (
+        ScatterGatherResult,
+        combine_experiment_outputs,
+    )
+    df1 = pd.DataFrame({"x": [1]})
+    df2 = pd.DataFrame({"x": [2]})
+    out = combine_experiment_outputs([
+        ExperimentOutputSpec(dataframes={"d": df1}),
+        ExperimentOutputSpec(dataframes={"d": df2}),
+    ])
+    assert out.dataframes["d"].shape == (2, 1)
+
+    class DummyResponse:
+        pass
+
+    tmp_file = tmp_path / "res.pq"
+    df1.to_parquet(tmp_file)
+    monkeypatch.setattr(
+        "scythe.scatter_gather.fetch_uri", lambda uri, local_path, use_cache: tmp_file
+    )
+    res = ScatterGatherResult(uris={"d": S3Url("s3://b/k")})
+    gathered = res.to_gathered_experiment_runs()
+    assert "d" in gathered.success.dataframes
+
+
+def test_sift_results():
+    from scythe.scatter_gather import sift_results
+    class Spec(ExperimentInputSpec):
+        a: int
+        file: Path
+
+    s1 = Spec(experiment_id="e", sort_index=0, file=Path("f1"), a=1)
+    s2 = Spec(experiment_id="e", sort_index=1, file=Path("f2"), a=2)
+    safe, errors = sift_results([s1, s2], [1, ValueError("bad")])
+    assert safe == [1]
+    assert "bad" in errors["msg"].iloc[0]
+
+
+def test_additional_construct_and_errors(tmp_path):
+    from scythe.scatter_gather import ScatterGatherInput, RecursionMap, RecursionSpec
+    spec = MyInput(experiment_id="exp", sort_index=0, file=tmp_path/"f", a=1)
+    rm = RecursionMap(path=[RecursionSpec(factor=2, offset=0)], factor=2, max_depth=1)
+    sgi = ScatterGatherInput(
+        experiment_id="exp",
+        task_name="task",
+        specs_uri=S3Url("s3://b/k"),
+        recursion_map=rm,
+    )
+    sgi.__dict__["specs"] = [spec, spec]
+    key = sgi.construct_filekey("x", mode="final", workflow_run_id="wr", suffix="pq")
+    assert "final" in key
+    assert not sgi.is_root
+    assert sgi.is_base_case
+
+def test_sift_results_errors():
+    from scythe.scatter_gather import sift_results
+    from .test_registry_and_scatter import Out
+    class Spec(ExperimentInputSpec):
+        a: int
+        file: Path
+    s1 = Spec(experiment_id="e", sort_index=0, file=Path("f1"), a=1)
+    s2 = Spec(experiment_id="e", sort_index=1, file=Path("f2"), a=2)
+    safe, err = sift_results([s1, s2], [ValueError("bad"), Out()])
+    assert len(safe) == 1 and err is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,159 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scythe.base import (
+    ExperimentIndexAdditionalDataDoesNotMatchNRowsError,
+    ExperimentIndexAdditionalDataOverlapsWithSpecError,
+    ExperimentIndexNotSerializableError,
+    ExperimentInputSpec,
+    ExperimentOutputSpec,
+)
+from scythe.types import FileReference, S3Url
+from scythe.utils.filesys import fetch_uri
+from scythe.utils.results import (
+    make_onerow_multiindex_from_dict,
+    serialize_df_dict,
+    transpose_dataframe_dict,
+    save_and_upload_parquets,
+)
+
+class MyInputSpec(ExperimentInputSpec):
+    a: int
+    file: FileReference
+
+class MyOutputSpec(ExperimentOutputSpec):
+    b: int | None = None
+
+def test_local_path_and_file_reference_fields(tmp_path):
+    spec = MyInputSpec(experiment_id="exp", sort_index=0, file=Path("/tmp/x"), a=1)
+    # _file_reference_fields should detect 'file'
+    assert spec._file_reference_fields() == ["file"]
+    # local_path should put path into cache directory
+    uri = S3Url("s3://bucket/foo/bar.txt")
+    local = spec.local_path(uri)
+    assert str(local).endswith("cache/exp/foo/bar.txt")
+    # _local_input_artifact_file_paths should map field name to Path
+    paths = spec._local_input_artifact_file_paths
+    assert paths == {"file": Path("/tmp/x")}
+
+def test_make_multiindex_basic():
+    spec = MyInputSpec(experiment_id="exp", sort_index=1, file=Path("/tmp/f"), a=5)
+    mi = spec.make_multiindex({"extra": 42}, n_rows=2)
+    assert list(mi.names) == ["experiment_id", "sort_index", "workflow_run_id", "root_workflow_run_id", "a", "file", "extra", "sort_subindex"]
+    assert len(mi) == 2
+    assert mi.get_level_values("extra")[0] == 42
+
+def test_make_multiindex_errors():
+    spec = MyInputSpec(experiment_id="exp", sort_index=0, file=Path("/tmp/f"), a=2)
+    with pytest.raises(ExperimentIndexAdditionalDataDoesNotMatchNRowsError):
+        spec.make_multiindex([{"x": 1}, {"x": 2}, {"x": 3}], n_rows=2)
+    with pytest.raises(ExperimentIndexAdditionalDataOverlapsWithSpecError):
+        spec.make_multiindex({"a": 1})
+    with pytest.raises(ExperimentIndexAdditionalDataOverlapsWithSpecError):
+        spec.make_multiindex([{"a": 1}])
+    with pytest.raises(ExperimentIndexNotSerializableError):
+        spec.make_multiindex({"bad": set()}, n_rows=1)
+
+def test_add_scalars(tmp_path):
+    spec = MyInputSpec(experiment_id="exp", sort_index=0, file=tmp_path/"f", a=3)
+    out = MyOutputSpec(dataframes={"d": pd.DataFrame({"x": [1]})}, b=7)
+    out.add_scalars(spec)
+    assert "scalars" in out.dataframes
+    df = out.dataframes["scalars"]
+    assert df.iloc[0]["b"] == 7
+    # calling again should raise
+    with pytest.raises(Exception):
+        out.add_scalars(spec)
+
+def test_result_utils(tmp_path):
+    df1 = pd.DataFrame({"a": [1]})
+    df2 = pd.DataFrame({"a": [2]})
+    ser = serialize_df_dict({"first": df1})
+    assert ser["first"]["index"] == [0]
+    transposed = transpose_dataframe_dict([{"k": df1}, {"k": df2}])
+    assert transposed["k"].shape == (2, 1)
+    mi = make_onerow_multiindex_from_dict({"a": 1, "b": 2})
+    assert list(mi.names) == ["a", "b"]
+
+    class DummyS3:
+        def __init__(self):
+            self.uploaded = []
+        def upload_file(self, Bucket, Key, Filename):
+            self.uploaded.append((Bucket, Key, Path(Filename).read_bytes()))
+
+    s3 = DummyS3()
+    tmp_df = pd.DataFrame({"a": [3]})
+    uris = save_and_upload_parquets({"res": tmp_df}, s3, "bucket", lambda n: f"prefix/{n}.pq")
+    assert s3.uploaded and str(uris["res"]).startswith("s3://bucket/prefix")
+
+def test_fetch_uri_file_scheme(tmp_path):
+    src = tmp_path / "src.txt"
+    src.write_text("hello")
+    dest = tmp_path / "dst.txt"
+    uri = f"file://{src}"
+    out = fetch_uri(uri, dest, use_cache=False)
+    assert out.read_text() == "hello"
+    # repeated call with cache does not overwrite
+    src.write_text("changed")
+    fetch_uri(uri, dest, use_cache=True)
+    assert dest.read_text() == "hello"
+
+    with pytest.raises(FileNotFoundError):
+        fetch_uri("file:///nonexistent", dest, use_cache=False)
+
+def test_fetch_uri_http_and_s3(monkeypatch, tmp_path):
+    dest = tmp_path / "file.txt"
+    # patch requests.get
+    class DummyResponse:
+        def __init__(self, content):
+            self.content = content
+    def fake_get(url, timeout):
+        return DummyResponse(b"data")
+    monkeypatch.setattr("requests.get", fake_get)
+
+    out = fetch_uri("http://example.com/file", dest, use_cache=False)
+    assert dest.read_bytes() == b"data"
+
+    # patch s3 client
+    downloaded = {}
+    class DummyS3:
+        def download_file(self, bucket, key, filename):
+            downloaded[(bucket, key)] = filename
+    ds = DummyS3()
+    monkeypatch.setattr("scythe.utils.filesys.s3", ds)
+    uri = S3Url("s3://bucket/path/to")
+    fetch_uri(uri, dest, use_cache=False, s3=ds)
+    assert downloaded[("bucket", "path/to")] == str(dest)
+
+
+def test_fetch_uri_errors(tmp_path):
+    from scythe.utils.filesys import fetch_uri
+    from scythe.types import S3Url
+
+    with pytest.raises(ValueError):
+        fetch_uri(S3Url("s3://bucket"), tmp_path/"x")
+    class DummyAny:
+        def __init__(self, url):
+            self.scheme = "ftp"
+            self.path = "/foo"
+    with pytest.raises(NotImplementedError):
+        fetch_uri(DummyAny("ftp://x"), tmp_path/"x")
+
+def test_s3_utils(monkeypatch):
+    from scythe.utils.s3 import check_experiment_exists, raise_on_forbidden_experiment
+
+    class DS:
+        def __init__(self, count):
+            self.count = count
+        def list_objects_v2(self, Bucket, Prefix):
+            return {"KeyCount": self.count}
+
+    ds = DS(1)
+    assert check_experiment_exists(ds, "b", "p", "e")
+    ds.count = 0
+    assert not check_experiment_exists(ds, "b", "p", "e")
+    ds.count = 1
+    with pytest.raises(ValueError):
+        raise_on_forbidden_experiment(ds, "b", "p", "e")


### PR DESCRIPTION
## Summary
- add new suite exercising ScatterGather routines and helpers
- expand tests for fetch_uri edge cases, result serialization, and registry behavior
- cover allocation errors and scatter-gather recursion

## Testing
- `pytest -q`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_b_68818054144c832ba18e4b6315c06edb